### PR TITLE
Fix typos in System.Text/Encoding/GetPreamble method code snippets 

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR_System/system.Text.Encoding.GetPreamble Example/CPP/preamble.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.Text.Encoding.GetPreamble Example/CPP/preamble.cpp
@@ -11,7 +11,7 @@ int main()
    array<Byte>^preamble = unicode->GetPreamble();
    
    // Make sure a preamble was returned 
-   // and is large enough to containa BOM.
+   // and is large enough to contain a BOM.
    if ( preamble->Length >= 2 )
    {
       

--- a/snippets/csharp/System.Text/Encoding/GetPreamble/preamble.cs
+++ b/snippets/csharp/System.Text/Encoding/GetPreamble/preamble.cs
@@ -15,7 +15,7 @@ namespace GetPreambleExample
          byte[] preamble = unicode.GetPreamble();
 
          // Make sure a preamble was returned 
-         // and is large enough to containa BOM.
+         // and is large enough to contain a BOM.
          if(preamble.Length >= 2)
          {
             if(preamble[0] == 0xFE && preamble[1] == 0xFF)


### PR DESCRIPTION
## Summary

Fixed minor typos in code snippets for `System.Test.Encoding.GetPreamble` method - "containa" should be "contain a".

